### PR TITLE
Typo Fix: "Accomodate" to "Accommodate"

### DIFF
--- a/projecto/ForTheCompiler/include/s__rope.h
+++ b/projecto/ForTheCompiler/include/s__rope.h
@@ -352,7 +352,7 @@ public:
   enum __attribute__((__packed__)) _Tag {_S_leaf, _S_concat, _S_substringfn, _S_function};
   // Apparently needed by VC++
   // The data fields of leaves are allocated with some
-  // extra space, to accomodate future growth and for basic
+  // extra space, to accommodate future growth and for basic
   // character types, to hold a trailing eos character.
   enum __attribute__((__packed__)) { _S_alloc_granularity = 8 };
 


### PR DESCRIPTION
Hey there! I've been helping people find simple typo's in their files. "_Accommodate_" is on the list of the Oxford Dictionary's list of top misspelled words according to the [Oxford English Corpus](http://en.oxforddictionaries.com//the-oxford-english-corpus).